### PR TITLE
DNSBL interface and spamhaus implementation

### DIFF
--- a/internal/dnsbl/dnsbl.go
+++ b/internal/dnsbl/dnsbl.go
@@ -1,0 +1,36 @@
+package dnsbl
+
+import "context"
+
+// Codes represent error codes and their meanings
+type Code string
+
+const (
+	CodeSpamhausSBL       = "127.0.0.2"
+	CodeSpamhausSBLCSS    = "127.0.0.3"
+	CodeSpamhausCBL       = "127.0.0.4"
+	CodeSpamhausDROP      = "127.0.0.10"
+	CodeISP               = "127.0.0.10"
+	CodeSpamhaus          = "127.0.0.11"
+	CodeErrorTyping       = "127.255.255.252"
+	CodeErrorOpenResolver = "127.255.255.254"
+	CodeRateLimit         = "127.255.255.255"
+	CodeUnknown           = "0.0.0.0"
+)
+
+// Response represents a Response from the DNSBL service
+type Response struct {
+	Codes []Code
+}
+
+// newResponse returns a new empty response
+func newResponse() *Response {
+	return &Response{
+		Codes: []Code{},
+	}
+}
+
+// DNSBL represents a service interface for interacting with DNSBL services
+type DNSBL interface {
+	Query(ctx context.Context, ip string) (*Response, error)
+}

--- a/internal/dnsbl/spamhaus.go
+++ b/internal/dnsbl/spamhaus.go
@@ -1,0 +1,79 @@
+package dnsbl
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+type spamhaus struct {
+	network  string
+	resolver *net.Resolver
+}
+
+type options struct {
+	network    string
+	dnsServer  string
+	goResolver bool
+}
+
+type Option func(*options)
+
+func NewSpamhaus(opts ...Option) DNSBL {
+	options := &options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	if options.network == "" {
+		options.network = "tcp"
+	}
+
+	r := &net.Resolver{
+		PreferGo: options.goResolver,
+	}
+	if options.dnsServer != "" {
+		r.Dial = customDialer(options.network, options.dnsServer)
+	}
+
+	return &spamhaus{
+		network:  options.network,
+		resolver: r,
+	}
+}
+
+// Query does a DNSBL query for a single IP address to Spamhaus
+func (sh *spamhaus) Query(ctx context.Context, ip string) (*Response, error) {
+	ip = reverse(ip)
+	ip = fmt.Sprintf("%s.zen.spamhaus.org", ip)
+
+	resp, err := sh.resolver.LookupIP(ctx, sh.network, ip)
+	if err != nil {
+		return nil, fmt.Errorf("spamhaus query: %w", err)
+	}
+
+	r := newResponse()
+	for _, ip := range resp {
+		r.Codes = append(r.Codes, Code(ip))
+	}
+
+	return r, nil
+}
+
+type dialerFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// customDialer returns
+func customDialer(network, server string) dialerFunc {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return net.Dial(network, server)
+	}
+}
+
+func reverse(str string) string {
+	rs := []rune(str)
+	last := len(rs) - 1
+	for i := 0; i < len(rs)/2; i++ {
+		rs[i], rs[last-i] = rs[last-i], rs[i]
+	}
+
+	return string(rs)
+}


### PR DESCRIPTION
This PR adds a `DNSBL` interface that can be used to query IP address against a Spamhaus service.